### PR TITLE
make WHERE clause unambiguous in join queries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'com.fsryan'
-version = '0.5.0'
+version = '0.5.1'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -67,10 +67,10 @@ bintray {
         vcsUrl = 'https://github.com/ryansgot/forsuredbcompiler.git'
         publicDownloadNumbers = true
         version {
-            name = '0.5.0'
+            name = '0.5.1'
             desc = 'Guts of the ForSureDB project, containing code to generate source and assets'
             released  = new Date()
-            vcsTag = 'v0.5.0'
+            vcsTag = 'v0.5.1'
         }
     }
 }
@@ -81,7 +81,7 @@ publishing {
             from components.java
             groupId = 'com.fsryan'
             artifactId = 'forsuredbcompiler'
-            version = '0.5.0'
+            version = '0.5.1'
 
             Artifact sourcesJar
             Artifact javadocJar

--- a/src/main/java/com/forsuredb/api/Finder.java
+++ b/src/main/java/com/forsuredb/api/Finder.java
@@ -45,11 +45,13 @@ public abstract class Finder<U, R extends RecordContainer, G extends FSGetApi, S
         }
     }
 
+    private final String tableName;
     private final StringBuffer whereBuf = new StringBuffer();
     private final List<String> replacementsList = new ArrayList<>();
     protected final Conjunction<U, R, G, S, F> conjunction;
 
     public Finder(final Resolver<U, R, G, S, F> resolver) {
+        this.tableName = resolver.tableName();
         conjunction = new Conjunction<U, R, G, S, F>() {
             @Override
             public Resolver<U, R, G, S, F> andFinally() {
@@ -414,6 +416,7 @@ public abstract class Finder<U, R extends RecordContainer, G extends FSGetApi, S
         if (!canAddClause(column, operator, value)) {
             return;
         }
+        column = tableName + "." + column;  // <-- disambiguate column from other tables that have same name column
         whereBuf.append(whereBuf.length() == 0 ? column : " AND " + column)
                 .append(" ").append(operator.getSymbol())
                 .append(" ").append(operator == Operator.LIKE ? "%?%" : "?");


### PR DESCRIPTION
@SteveChalker @kevinalbert

This fixes https://github.com/ryansgot/forsuredbcompiler/issues/2

The issue was that the Finder class was not disambiguating columns by table name, so when a join occurred between two tables that had columns with the same name, the query compilation failed.