### PR TITLE
Feature/distinct

### DIFF
--- a/forsuredbapi/build.gradle
+++ b/forsuredbapi/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: "jacoco"
 
 group = 'com.fsryan.forsuredb'
-version = '0.9.5'
+version = '0.10.0'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -75,10 +75,10 @@ bintray {
         vcsUrl = 'https://github.com/ryansgot/forsuredbcompiler.git'
         publicDownloadNumbers = true
         version {
-            name = '0.9.5'
+            name = '0.10.0'
             desc = 'Classes necessary for integration with forsuredb'
             released  = new Date()
-            vcsTag = 'v0.9.5'
+            vcsTag = 'v0.10.0'
         }
     }
 }
@@ -89,7 +89,7 @@ publishing {
             from components.java
             groupId = 'com.fsryan.forsuredb'
             artifactId = 'forsuredbapi'
-            version = '0.9.5'
+            version = '0.10.0'
 
             Artifact sourcesJar
             Artifact javadocJar

--- a/forsuredbapi/src/main/java/com/fsryan/forsuredb/api/FSProjection.java
+++ b/forsuredbapi/src/main/java/com/fsryan/forsuredb/api/FSProjection.java
@@ -28,4 +28,9 @@ public interface FSProjection {
      * @return All of the columns to be retrieved in a SELECT query
      */
     String[] columns();
+
+    /**
+     * @return Whether the query should be for distinct column values.
+     */
+    boolean isDistinct();
 }

--- a/forsuredbcompiler/build.gradle
+++ b/forsuredbcompiler/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: "jacoco"
 
 group = 'com.fsryan.forsuredb'
-version = '0.9.5'
+version = '0.10.0'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -84,10 +84,10 @@ bintray {
         vcsUrl = 'https://github.com/ryansgot/forsuredbcompiler.git'
         publicDownloadNumbers = true
         version {
-            name = '0.9.5'
+            name = '0.10.0'
             desc = 'Guts of the ForSureDB project, containing code to generate source and assets'
             released  = new Date()
-            vcsTag = 'v0.9.5'
+            vcsTag = 'v0.10.0'
         }
     }
 }
@@ -98,7 +98,7 @@ publishing {
             from components.java
             groupId = 'com.fsryan.forsuredb'
             artifactId = 'forsuredbcompiler'
-            version = '0.9.5'
+            version = '0.10.0'
 
             Artifact sourcesJar
             Artifact javadocJar

--- a/forsuredbcompiler/src/test/resources/example_resolver_with_child_foreign_key.txt
+++ b/forsuredbcompiler/src/test/resources/example_resolver_with_child_foreign_key.txt
@@ -48,6 +48,11 @@ public abstract class TestTable3Resolver<T extends TestTable3Resolver> extends R
         public String[] columns() {
             return columns;
         }
+
+        @Override
+        public boolean isDistinct() {
+            return false;
+        }
     };
 
     private static final ImmutableBiMap<String, String> COLUMN_TO_METHOD_NAME_BI_MAP = new ImmutableBiMap.Builder<String, String>()
@@ -77,7 +82,7 @@ public abstract class TestTable3Resolver<T extends TestTable3Resolver> extends R
      * </p>
      */
     public JoinTestTable2<T> joinTestTable2(final FSJoin.Type type) {
-        addJoin(new FSJoin(type, "test_table_3", "_id", "test_table_2", "test_table_3_id"), TestTable2Resolver.PROJECTION);
+        addJoin(new FSJoin(type, "test_table_3", "_id", "test_table_2", "test_table_3_id"));
         return new JoinTestTable2(infoFactory, this);
     }
 
@@ -147,8 +152,8 @@ public abstract class TestTable3Resolver<T extends TestTable3Resolver> extends R
         }
 
         @Override
-        protected void addJoin(FSJoin join, FSProjection foreignTableProjection) {
-            parent.addJoin(join, foreignTableProjection);
+        protected void addJoin(FSJoin join) {
+            parent.addJoin(join);
         }
     }
 }

--- a/forsuredbcompiler/src/test/resources/example_resolver_with_parent_and_child_foreign_key.txt
+++ b/forsuredbcompiler/src/test/resources/example_resolver_with_parent_and_child_foreign_key.txt
@@ -48,6 +48,11 @@ public abstract class TestTable2Resolver<T extends TestTable2Resolver> extends R
         public String[] columns() {
             return columns;
         }
+
+        @Override
+        public boolean isDistinct() {
+            return false;
+        }
     };
 
     private static final ImmutableBiMap<String, String> COLUMN_TO_METHOD_NAME_BI_MAP = new ImmutableBiMap.Builder<String, String>()
@@ -74,7 +79,7 @@ public abstract class TestTable2Resolver<T extends TestTable2Resolver> extends R
      * </p>
      */
     public JoinTestTable3<T> joinTestTable3(final FSJoin.Type type) {
-        addJoin(new FSJoin(type, "test_table_3", "_id", "test_table_2", "test_table_3_id"), TestTable3Resolver.PROJECTION);
+        addJoin(new FSJoin(type, "test_table_3", "_id", "test_table_2", "test_table_3_id"));
         return new JoinTestTable3(infoFactory, this);
     }
 
@@ -85,7 +90,7 @@ public abstract class TestTable2Resolver<T extends TestTable2Resolver> extends R
      * </p>
      */
     public JoinTestTable<T> joinTestTable(final FSJoin.Type type) {
-        addJoin(new FSJoin(type, "test_table_2", "_id", "test_table", "test_table_2_id"), TestTableResolver.PROJECTION);
+        addJoin(new FSJoin(type, "test_table_2", "_id", "test_table", "test_table_2_id"));
         return new JoinTestTable(infoFactory, this);
     }
 
@@ -155,8 +160,8 @@ public abstract class TestTable2Resolver<T extends TestTable2Resolver> extends R
         }
 
         @Override
-        protected void addJoin(FSJoin join, FSProjection foreignTableProjection) {
-            parent.addJoin(join, foreignTableProjection);
+        protected void addJoin(FSJoin join) {
+            parent.addJoin(join);
         }
     }
 
@@ -190,8 +195,8 @@ public abstract class TestTable2Resolver<T extends TestTable2Resolver> extends R
         }
 
         @Override
-        protected void addJoin(FSJoin join, FSProjection foreignTableProjection) {
-            parent.addJoin(join, foreignTableProjection);
+        protected void addJoin(FSJoin join) {
+            parent.addJoin(join);
         }
     }
 }


### PR DESCRIPTION
This is a pretty big PR . . . its a big feature addition to the querying API which should be backwards compatible with your framework integration library (forsuredbandroid is the only one I know of). You can now
- narrow down the width of each record by calling the ```columns(String...)``` method of the ```Finder``` class
- query for distinct values by calling the ```distinct(String...)``` method of the ```Finder``` class

I also added some pretty copious java docs.