### PR TITLE
fix MigrationContext building with respect to adding indices

### DIFF
--- a/forsuredbcompiler/src/main/java/com/fsryan/forsuredb/migration/MigrationContext.java
+++ b/forsuredbcompiler/src/main/java/com/fsryan/forsuredb/migration/MigrationContext.java
@@ -138,6 +138,9 @@ public class MigrationContext implements TableContext {
             case ALTER_TABLE_ADD_COLUMN:
                 columnBuilderMap.put(columnKey(m), table.getColumn(m.columnName()).toBuilder());
                 break;
+            case ADD_INDEX:
+                columnBuilderMap.put(columnKey(m), table.getColumn(m.columnName()).toBuilder().index(true));
+                break;
             default:
                 APLog.w(LOG_TAG, "Not handling update of type " + m.type() + "; this could cause the migration context to misrepresent the existing schema.");
         }

--- a/forsuredbcompiler/src/test/java/com/fsryan/forsuredb/TestData.java
+++ b/forsuredbcompiler/src/test/java/com/fsryan/forsuredb/TestData.java
@@ -113,6 +113,10 @@ public class TestData {
         return migration(Migration.Type.ALTER_TABLE_ADD_COLUMN).tableName(tableName);
     }
 
+    public static ProgressiveMigrationBuilder addIndexMigration(String tableName) {
+        return migration(Migration.Type.ADD_INDEX).tableName(tableName);
+    }
+
     public static ProgressiveMigrationBuilder addForeignKeyReferenceMigration(String tableName) {
         return migration(Migration.Type.ADD_FOREIGN_KEY_REFERENCE).tableName(tableName);
     }

--- a/forsuredbcompiler/src/test/java/com/fsryan/forsuredb/migration/MigrationContextTest.java
+++ b/forsuredbcompiler/src/test/java/com/fsryan/forsuredb/migration/MigrationContextTest.java
@@ -111,5 +111,4 @@ public abstract class MigrationContextTest {
                     secondExpectedSchema);
         }
     }
-
 }

--- a/forsuredbcompiler/src/test/java/com/fsryan/forsuredb/migration/OneMigrationSetSuccessConditions.java
+++ b/forsuredbcompiler/src/test/java/com/fsryan/forsuredb/migration/OneMigrationSetSuccessConditions.java
@@ -74,6 +74,19 @@ public class OneMigrationSetSuccessConditions extends MigrationContextTest.OneMi
                                         .build())
                                 .build()
                                 .tableMap()
+                },
+                {   // 04: one table with a column that has an index
+                        Arrays.asList(
+                                createTableMigration("table1"),
+                                addColumnMigration("table1").columnName("table_1_index").build(),
+                                addIndexMigration("table1").columnName("table_1_index").build()
+                        ),
+                        newTableContext()
+                                .addTable(table("table1")
+                                        .addToColumns(longCol().columnName("table_1_index").index(true).build())
+                                        .build())
+                                .build()
+                                .tableMap()
                 }
         });
     }

--- a/forsuredbcompiler/src/test/java/com/fsryan/forsuredb/migration/TwoMigrationSetsSuccessConditions.java
+++ b/forsuredbcompiler/src/test/java/com/fsryan/forsuredb/migration/TwoMigrationSetsSuccessConditions.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -193,6 +194,26 @@ public class TwoMigrationSetsSuccessConditions extends MigrationContextTest.TwoM
                                         .build())
                                 .build()
                                 .tableMap()
+                },
+                {   // 07: one table with a column that has an index added after creation
+                        Arrays.asList(
+                                createTableMigration("table1"),
+                                addColumnMigration("table1").columnName("table_1_index").build()
+                        ),
+                        newTableContext()
+                                .addTable(table("table1")
+                                        .addToColumns(longCol().columnName("table_1_index").build())
+                                        .build())
+                                .build()
+                                .tableMap(),
+                        Collections.singletonList(addIndexMigration("table1").columnName("table_1_index").build()),
+                        newTableContext()
+                                .addTable(table("table1")
+                                        .addToColumns(longCol().columnName("table_1_index").index(true).build())
+                                        .build())
+                                .build()
+                                .tableMap(),
+
                 }
         });
     }

--- a/forsuredbjdbc-example/src/main/java/com/fsryan/forsuredb/jdbcexample/AllTypesTable.java
+++ b/forsuredbjdbc-example/src/main/java/com/fsryan/forsuredb/jdbcexample/AllTypesTable.java
@@ -4,6 +4,7 @@ import com.fsryan.forsuredb.annotations.FSColumn;
 import com.fsryan.forsuredb.annotations.FSDefault;
 import com.fsryan.forsuredb.annotations.FSStaticData;
 import com.fsryan.forsuredb.annotations.FSTable;
+import com.fsryan.forsuredb.annotations.Index;
 import com.fsryan.forsuredb.api.FSGetApi;
 import com.fsryan.forsuredb.api.Retriever;
 
@@ -14,7 +15,7 @@ import java.util.Date;
 @FSTable("all_types")
 @FSStaticData("all_types_static_data.xml")
 public interface AllTypesTable extends FSGetApi {
-    @FSColumn("int_column") @FSDefault("42") int intColumn(Retriever retriever);
+    @FSColumn("int_column") @FSDefault("42") @Index int intColumn(Retriever retriever);
     @FSColumn("integer_wrapper_column") @FSDefault("1792") Integer integerWrapperColumn(Retriever retriever);
     @FSColumn("long_column") long longColumn(Retriever retriever);
     @FSColumn("long_wrapper_column") Long longWrapperColumn(Retriever retriever);

--- a/forsuredbjdbc-example/src/main/resources/1533340512956.migration.json
+++ b/forsuredbjdbc-example/src/main/resources/1533340512956.migration.json
@@ -1,0 +1,336 @@
+{
+  "ordered_migrations": [
+    {
+      "table_name": "all_types",
+      "column_name": "int_column",
+      "migration_type": "ADD_INDEX"
+    }
+  ],
+  "target_schema": {
+    "references_all_types": {
+      "column_info_map": {
+        "deleted": {
+          "method_name": "deleted",
+          "column_name": "deleted",
+          "column_type": "boolean",
+          "index": false,
+          "default_value": "0",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "all_types_id": {
+          "method_name": "allTypesId",
+          "column_name": "all_types_id",
+          "column_type": "long",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "created": {
+          "method_name": "created",
+          "column_name": "created",
+          "column_type": "java.util.Date",
+          "index": false,
+          "default_value": "CURRENT_TIMESTAMP",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "doc": {
+          "method_name": "doc",
+          "column_name": "doc",
+          "column_type": "java.lang.String",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "blob_doc": {
+          "method_name": "blobDoc",
+          "column_name": "blob_doc",
+          "column_type": "byte[]",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "modified": {
+          "method_name": "modified",
+          "column_name": "modified",
+          "column_type": "java.util.Date",
+          "index": false,
+          "default_value": "CURRENT_TIMESTAMP",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "composed_int": {
+          "method_name": "composedInt",
+          "column_name": "composed_int",
+          "column_type": "int",
+          "index": true,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "_id": {
+          "method_name": "id",
+          "column_name": "_id",
+          "column_type": "long",
+          "index": false,
+          "unique": false,
+          "primary_key": true,
+          "searchable": true,
+          "orderable": true
+        },
+        "class_name": {
+          "method_name": "className",
+          "column_name": "class_name",
+          "column_type": "java.lang.String",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        }
+      },
+      "table_name": "references_all_types",
+      "qualified_class_name": "com.fsryan.forsuredb.jdbcexample.ReferencesAllTypesTable",
+      "static_data_asset": "references_all_types_static_data.xml",
+      "doc_store_parameterization": "com.fsryan.forsuredb.jdbcexample.MyPojo",
+      "primary_key": [
+        "_id"
+      ],
+      "primary_key_on_conflict": "",
+      "foreign_keys": [
+        {
+          "foreign_table_api_class_name": "com.fsryan.forsuredb.jdbcexample.AllTypesTable",
+          "foreign_table_name": "all_types",
+          "local_to_foreign_column_map": {
+            "all_types_id": "_id"
+          },
+          "update_action": "CASCADE",
+          "delete_action": "CASCADE"
+        }
+      ]
+    },
+    "all_types": {
+      "column_info_map": {
+        "float_wrapper_column": {
+          "method_name": "floatWrapperColumn",
+          "column_name": "float_wrapper_column",
+          "column_type": "java.lang.Float",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "boolean_wrapper_column": {
+          "method_name": "booleanWrapperColumn",
+          "column_name": "boolean_wrapper_column",
+          "column_type": "java.lang.Boolean",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "long_wrapper_column": {
+          "method_name": "longWrapperColumn",
+          "column_name": "long_wrapper_column",
+          "column_type": "java.lang.Long",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "string_column": {
+          "method_name": "stringColumn",
+          "column_name": "string_column",
+          "column_type": "java.lang.String",
+          "index": false,
+          "default_value": "Some String with a \u0027",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "created": {
+          "method_name": "created",
+          "column_name": "created",
+          "column_type": "java.util.Date",
+          "index": false,
+          "default_value": "CURRENT_TIMESTAMP",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "deleted": {
+          "method_name": "deleted",
+          "column_name": "deleted",
+          "column_type": "boolean",
+          "index": false,
+          "default_value": "0",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "big_decimal_column": {
+          "method_name": "bigDecimalColumn",
+          "column_name": "big_decimal_column",
+          "column_type": "java.math.BigDecimal",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "big_integer_column": {
+          "method_name": "bigIntegerColumn",
+          "column_name": "big_integer_column",
+          "column_type": "java.math.BigInteger",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "date_column": {
+          "method_name": "dateColumn",
+          "column_name": "date_column",
+          "column_type": "java.util.Date",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "int_column": {
+          "method_name": "intColumn",
+          "column_name": "int_column",
+          "column_type": "int",
+          "index": true,
+          "default_value": "42",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "double_column": {
+          "method_name": "doubleColumn",
+          "column_name": "double_column",
+          "column_type": "double",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "byte_array_column": {
+          "method_name": "byteArrayColumn",
+          "column_name": "byte_array_column",
+          "column_type": "byte[]",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "modified": {
+          "method_name": "modified",
+          "column_name": "modified",
+          "column_type": "java.util.Date",
+          "index": false,
+          "default_value": "CURRENT_TIMESTAMP",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "float_column": {
+          "method_name": "floatColumn",
+          "column_name": "float_column",
+          "column_type": "float",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "long_column": {
+          "method_name": "longColumn",
+          "column_name": "long_column",
+          "column_type": "long",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "_id": {
+          "method_name": "id",
+          "column_name": "_id",
+          "column_type": "long",
+          "index": false,
+          "unique": false,
+          "primary_key": true,
+          "searchable": true,
+          "orderable": true
+        },
+        "double_wrapper_column": {
+          "method_name": "doubleWrapperColumn",
+          "column_name": "double_wrapper_column",
+          "column_type": "java.lang.Double",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "integer_wrapper_column": {
+          "method_name": "integerWrapperColumn",
+          "column_name": "integer_wrapper_column",
+          "column_type": "java.lang.Integer",
+          "index": false,
+          "default_value": "1792",
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        },
+        "boolean_column": {
+          "method_name": "booleanColumn",
+          "column_name": "boolean_column",
+          "column_type": "boolean",
+          "index": false,
+          "unique": false,
+          "primary_key": false,
+          "searchable": true,
+          "orderable": true
+        }
+      },
+      "table_name": "all_types",
+      "qualified_class_name": "com.fsryan.forsuredb.jdbcexample.AllTypesTable",
+      "static_data_asset": "all_types_static_data.xml",
+      "primary_key": [
+        "_id"
+      ],
+      "primary_key_on_conflict": "",
+      "foreign_keys": []
+    }
+  },
+  "db_version": 5
+}


### PR DESCRIPTION
Previously, ADD_INDEX migrations were not getting counted when
building up the migration context. This led to the DiffGenerator
always detecting that the index needed to be added.

The solution was to update the MigrationContext.update method to
appropriately update its representation of the Column that had its
index added after it was originally created without an index.