### PR TITLE
remove addEqualsOrChainToBuf method

### DIFF
--- a/forsuredbapi/src/main/java/com/fsryan/forsuredb/api/DocStoreFinder.java
+++ b/forsuredbapi/src/main/java/com/fsryan/forsuredb/api/DocStoreFinder.java
@@ -1,8 +1,5 @@
 package com.fsryan.forsuredb.api;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder<R, F>> extends Finder<R, F> {
     
     public DocStoreFinder(R resolver) {
@@ -10,76 +7,91 @@ public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder
     }
 
     /**
-     * <p>
-     *     add criteria to a query that is a convenience for calling {@link #byClassName(String, String...)} with the
-     *     {@link Class} object instead of the fully qualified class name.
-     * </p>
+     * <p>add criteria to a query that is a convenience for calling
+     * {@link #byClassName(String, String...)} with the @link Class} object
+     * instead of the fully qualified class name.
      * @param exactClassMatch the exact class you want
      * @param orExactClassMatches the other possible class matches
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
      * @see #byClassName(String, String...)
      */
     public Conjunction.GroupableAndOr<R, F> byClass(Class exactClassMatch, Class... orExactClassMatches) {
-        String[] otherClassNames = new String[orExactClassMatches.length];
-        for (int i = 0; i < orExactClassMatches.length; i++) {
-            otherClassNames[i] = orExactClassMatches[i].getName();
+        whereElements.add(WhereElement.createGroupStart());
+        addClassToBuf(exactClassMatch, OP_EQ);
+        for (int i = 0; i < (orExactClassMatches == null ? 0 : orExactClassMatches.length); i++) {
+            whereElements.add(WhereElement.createOr());
+            addClassToBuf(orExactClassMatches[i], OP_EQ);
         }
-        return byClassName(exactClassMatch == null ? "" : exactClassMatch.getName(), otherClassNames);
+        whereElements.add(WhereElement.createGroupEnd());
+        return conjunction;
     }
 
     /**
-     * <p>
-     *     add criteria to a query that is a convenience for calling {@link #byClassNameNot(String)} with the
-     *     {@link Class} object instead of the fully qualified class name.
-     * </p>
-     * @param exclusion
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
-     * @see #byClassNameNot(String)
+     * <p>add criteria to a query that is a convenience for calling
+     * {@link #byClassNameNot(String, String...)} with the {@link Class} object
+     *  instead of the fully qualified class name.
+     * @param exclusion the {@link Class} to exclude (by its name)
+     * @param furtherExclusions further classes to exclude (by their names)
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
+     * @see #byClassNameNot(String, String...)
      */
-    public Conjunction.GroupableAndOr<R, F> byClassNot(Class exclusion) {
-        return byClassNameNot(exclusion == null ? "" : exclusion.getName());
+    public Conjunction.GroupableAndOr<R, F> byClassNot(Class exclusion, Class... furtherExclusions) {
+        whereElements.add(WhereElement.createGroupStart());
+        addClassToBuf(exclusion, OP_NE);
+        for (int i = 0; i < (furtherExclusions == null ? 0 : furtherExclusions.length); i++) {
+            whereElements.add(WhereElement.createAnd());
+            addClassToBuf(furtherExclusions[i], OP_NE);
+        }
+        whereElements.add(WhereElement.createGroupEnd());
+        return conjunction;
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires exact match for class_name
-     * </p>
+     * <p>add criteria to a query that requires exact match for class_name or a
+     * match for any of the other strings passed in the varargs argument
      * @param exactMatch the exact class name of the class you want
      * @param orExactMatches the other possible matches
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
      */
     public Conjunction.GroupableAndOr<R, F> byClassName(String exactMatch, String... orExactMatches) {
-        if (orExactMatches.length == 0) {
-            addToBuf("class_name", OP_EQ, exactMatch);
-        } else {
-            List<String> inclusionFilter = new ArrayList<String>(1 + orExactMatches.length);
-            inclusionFilter.add(exactMatch);
-            for (String toInclude : orExactMatches) {
-                inclusionFilter.add(toInclude);
-            }
-            addEqualsOrChainToBuf("class_name", inclusionFilter);
+        whereElements.add(WhereElement.createGroupStart());
+        addClassToBuf(exactMatch, OP_EQ);
+        for (int i = 0; i < (orExactMatches == null ? 0 : orExactMatches.length); i++) {
+            whereElements.add(WhereElement.createOr());
+            addClassToBuf(orExactMatches[i], OP_EQ);
         }
+        whereElements.add(WhereElement.createGroupEnd());
         return conjunction;
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires exclusion for class_name
-     * </p>
-     * @param exclusion
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
+     * <p>add criteria to a query that requires exclusion for class_name and
+     * any other class_name passed in
+     * @param exclusion a class name to exclude
+     * @param furtherExclusions further class names to exclude
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
      */
-    public Conjunction.GroupableAndOr<R, F> byClassNameNot(String exclusion) {
-        addToBuf("class_name", OP_NE, exclusion);
+    public Conjunction.GroupableAndOr<R, F> byClassNameNot(String exclusion, String... furtherExclusions) {
+        whereElements.add(WhereElement.createGroupStart());
+        addClassToBuf(exclusion, OP_NE);
+        for (int i = 0; i < (furtherExclusions == null ? 0 : furtherExclusions.length); i++) {
+            whereElements.add(WhereElement.createAnd());
+            addClassToBuf(furtherExclusions[i], OP_NE);
+        }
+        whereElements.add(WhereElement.createGroupEnd());
         return conjunction;
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires nonInclusiveUpperBound for class_name
-     * </p>
+     * <p>add criteria to a query that requires nonInclusiveUpperBound for
+     * class_name
      * @param nonInclusiveUpperBound
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
      */
     public Conjunction.GroupableAndOr<R, F> byClassNameLessThan(String nonInclusiveUpperBound) {
         addToBuf("class_name", OP_LT, nonInclusiveUpperBound);
@@ -87,11 +99,11 @@ public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires nonInclusiveLowerBound for class_name
-     * </p>
+     * <p>add criteria to a query that requires nonInclusiveLowerBound for
+     * class_name
      * @param nonInclusiveLowerBound
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
      */
     public Conjunction.GroupableAndOr<R, F> byClassNameGreaterThan(String nonInclusiveLowerBound) {
         addToBuf("class_name", OP_GT, nonInclusiveLowerBound);
@@ -99,11 +111,11 @@ public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires inclusiveUpperBound for class_name
-     * </p>
+     * <p>add criteria to a query that requires inclusiveUpperBound for
+     * class_name
      * @param inclusiveUpperBound
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
      */
     public Conjunction.GroupableAndOr<R, F> byClassNameLessThanInclusive(String inclusiveUpperBound) {
         addToBuf("class_name", OP_LE, inclusiveUpperBound);
@@ -111,11 +123,11 @@ public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires inclusiveLowerBound for class_name
-     * </p>
+     * <p>add criteria to a query that requires inclusiveLowerBound for
+     * class_name
      * @param inclusiveLowerBound
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
      */
     public Conjunction.GroupableAndOr<R, F> byClassNameGreaterThanInclusive(String inclusiveLowerBound) {
         addToBuf("class_name", OP_GE, inclusiveLowerBound);
@@ -123,11 +135,11 @@ public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires nonInclusiveLowerBound for class_name
-     * </p>
+     * <p>add criteria to a query that requires nonInclusiveLowerBound for
+     * class_name
      * @param nonInclusiveLowerBound
-     * @return a {@link Between} that allows you to provide an upper bound for this criteria
+     * @return a {@link Between} that allows you to provide an upper bound for
+     * this criteria
      */
     public Between<R, F> byClassNameBetween(String nonInclusiveLowerBound) {
         addToBuf("class_name", OP_GT, nonInclusiveLowerBound);
@@ -135,11 +147,11 @@ public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires inclusiveLowerBound for class_name
-     * </p>
+     * <p>add criteria to a query that requires inclusiveLowerBound for
+     * class_name
      * @param inclusiveLowerBound
-     * @return a {@link Between} that allows you to provide an upper bound for this criteria
+     * @return a {@link Between} that allows you to provide an upper bound for
+     * this criteria
      */
     public Between<R, F> byClassNameBetweenInclusive(String inclusiveLowerBound) {
         addToBuf("class_name", OP_GE, inclusiveLowerBound);
@@ -147,14 +159,27 @@ public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder
     }
 
     /**
-     * <p>
-     *   add criteria to a query that requires like for class_name
-     * </p>
+     * <p>add criteria to a query that requires like for class_name
      * @param like
-     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
+     * @return a {@link Conjunction.GroupableAndOr} that allows you to continue
+     * adding more query criteria
      */
     public Conjunction.GroupableAndOr<R, F> byClassNameLike(String like) {
         addToBuf("class_name", OP_LIKE, like);
         return conjunction;
+    }
+
+    private void addClassToBuf(Class cls, int op) {
+        if (cls == null) {
+            throw new IllegalArgumentException("cannot search for null class");
+        }
+        addClassToBuf(cls.getName(), op);
+    }
+
+    private void addClassToBuf(String clsName, int op) {
+        if (clsName == null) {
+            throw new IllegalArgumentException("cannot search for null class name");
+        }
+        addToBuf("class_name", op, clsName);
     }
 }

--- a/forsuredbapi/src/main/java/com/fsryan/forsuredb/api/DocStoreFinder.java
+++ b/forsuredbapi/src/main/java/com/fsryan/forsuredb/api/DocStoreFinder.java
@@ -1,9 +1,16 @@
 package com.fsryan.forsuredb.api;
 
+import com.fsryan.forsuredb.api.sqlgeneration.DBMSIntegrator;
+import com.fsryan.forsuredb.api.sqlgeneration.Sql;
+
 public class DocStoreFinder<R extends DocStoreResolver, F extends DocStoreFinder<R, F>> extends Finder<R, F> {
-    
+
     public DocStoreFinder(R resolver) {
-        super(resolver);
+        this(Sql.generator(), resolver);
+    }
+
+    DocStoreFinder(DBMSIntegrator dbmsIntegrator, R resolver) {
+        super(dbmsIntegrator, resolver);
     }
 
     /**

--- a/forsuredbapi/src/test/java/com/fsryan/forsuredb/api/FinderEqualsNotEqualsChainTest.java
+++ b/forsuredbapi/src/test/java/com/fsryan/forsuredb/api/FinderEqualsNotEqualsChainTest.java
@@ -1,0 +1,336 @@
+package com.fsryan.forsuredb.api;
+
+import com.fsryan.forsuredb.api.sqlgeneration.DBMSIntegrator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class FinderEqualsNotEqualsChainTest<F extends Finder, R extends Resolver> extends FinderTest<F, R> {
+
+    static final Date d1 = new Date();
+    static final Date d2 = new Date();
+
+    private final List<Finder.WhereElement> expectedEqualsOrElements;
+    private final List<Finder.WhereElement> expectedNotEqualsAndElements;
+    private final List<Object> expectedReplacements;
+
+    FinderEqualsNotEqualsChainTest(Class<R> resolverClass,
+                                   List<Finder.WhereElement> expectedEqualsOrElements,
+                                   List<Finder.WhereElement> expectedNotEqualsAndElements,
+                                   List<Object> expectedReplacements) {
+        super(resolverClass);
+        this.expectedEqualsOrElements = expectedEqualsOrElements;
+        this.expectedNotEqualsAndElements = expectedNotEqualsAndElements;
+        this.expectedReplacements = expectedReplacements;
+        assertValidExpectations();
+    }
+
+    @Test
+    public void shouldCorrectlyAddEqualsObjectsToFinder() {
+        callEqualMethod(finderUnderTest);
+        assertListEqual(expectedEqualsOrElements, accessWhereElements());
+        assertListEqual(expectedReplacements, accessReplacementsList());
+    }
+
+    @Test
+    public void shouldCorrectlyAddNotEqualsObjectsToFinder() {
+        callNotEqualMethod(finderUnderTest);
+        assertListEqual(expectedNotEqualsAndElements, accessWhereElements());
+        assertListEqual(expectedReplacements, accessReplacementsList());
+    }
+
+    protected abstract void callEqualMethod(F finderUnderTest);
+    protected abstract void callNotEqualMethod(F finderUnderTest);
+
+    private static <T> void assertListEqual(List<T> expected, List<T> actual) {
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals("unequal at index " + i, expected.get(i), actual.get(i));
+        }
+        assertEquals(expected.size(), actual.size());
+    }
+
+    @RunWith(Parameterized.class)
+    public static class IdChain extends ForFinder {
+
+        private final long firstId;
+        private final long[] subsequentIds;
+
+        public IdChain(long firstId,
+                       Object[] subsequentIds,
+                       List<Finder.WhereElement> expectedEqualsOrElements,
+                       List<Finder.WhereElement> expectedNotEqualsAndElements,
+                       List<Object> expectedReplacements) {
+            super(expectedEqualsOrElements, expectedNotEqualsAndElements, expectedReplacements);
+            this.firstId = firstId;
+            if (subsequentIds == null) {
+                this.subsequentIds = null;
+            } else {
+                this.subsequentIds = new long[subsequentIds.length];
+                for (int i = 0; i < subsequentIds.length; i++) {
+                    this.subsequentIds[i] = (Long) subsequentIds[i];
+                }
+            }
+        }
+
+        @Parameterized.Parameters
+        public static Iterable<Object[]> data() {
+            return testInput("_id", 5L, 6L, 7L, 8L, 9L);
+        }
+
+        @Override
+        protected void callEqualMethod(Finder finderUnderTest) {
+            finderUnderTest.byId(firstId, subsequentIds);
+        }
+
+        @Override
+        protected void callNotEqualMethod(Finder finderUnderTest) {
+            finderUnderTest.byIdNot(firstId, subsequentIds);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class CreatedChain extends ForFinder {
+
+        private final Date firstDate;
+        private final Date[] subsequentDates;
+
+        public CreatedChain(Date firstDate,
+                            Object[] subsequentDates,
+                            List<Finder.WhereElement> expectedEqualsOrElements,
+                            List<Finder.WhereElement> expectedNotEqualsAndElements,
+                            List<Object> expectedReplacements) {
+            super(expectedEqualsOrElements, expectedNotEqualsAndElements, expectedReplacements);
+            this.firstDate = firstDate;
+            this.subsequentDates = subsequentDates == null
+                    ? null
+                    : Arrays.copyOf(subsequentDates, subsequentDates.length, Date[].class);
+        }
+
+        @Parameterized.Parameters
+        public static Iterable<Object[]> data() {
+            return testInput("created", d1, d2);
+        }
+
+        @Override
+        protected void callEqualMethod(Finder finderUnderTest) {
+            finderUnderTest.byCreatedOn(firstDate, subsequentDates);
+        }
+
+        @Override
+        protected void callNotEqualMethod(Finder finderUnderTest) {
+            finderUnderTest.byNotCreatedOn(firstDate, subsequentDates);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class ModifiedChain extends ForFinder {
+
+        private final Date firstDate;
+        private final Date[] subsequentDates;
+
+        public ModifiedChain(Date firstDate,
+                             Object[] subsequentDates,
+                             List<Finder.WhereElement> expectedEqualsOrElements,
+                             List<Finder.WhereElement> expectedNotEqualsAndElements,
+                             List<Object> expectedReplacements) {
+            super(expectedEqualsOrElements, expectedNotEqualsAndElements, expectedReplacements);
+            this.firstDate = firstDate;
+            this.subsequentDates = subsequentDates == null
+                    ? null
+                    : Arrays.copyOf(subsequentDates, subsequentDates.length, Date[].class);
+        }
+
+        @Parameterized.Parameters
+        public static Iterable<Object[]> data() {
+            return testInput("modified", d1, d2);
+        }
+
+        @Override
+        protected void callEqualMethod(Finder finderUnderTest) {
+            finderUnderTest.byModifiedOn(firstDate, subsequentDates);
+        }
+
+        @Override
+        protected void callNotEqualMethod(Finder finderUnderTest) {
+            finderUnderTest.byNotModifiedOn(firstDate, subsequentDates);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class DocStoreClassChain extends ForDocStoreFinder {
+
+        private final Class firstClass;
+        private final Class[] subsequentClasses;
+
+        public DocStoreClassChain(String firstClass,
+                                  String[] subsequentClasses,
+                                  List<Finder.WhereElement> expectedEqualsOrElements,
+                                  List<Finder.WhereElement> expectedNotEqualsAndElements,
+                                  List<Object> expectedReplacements) throws Exception {
+            super(expectedEqualsOrElements, expectedNotEqualsAndElements, expectedReplacements);
+            this.firstClass = Class.forName(firstClass);
+            if (subsequentClasses == null) {
+                this.subsequentClasses = null;
+            } else {
+                this.subsequentClasses = new Class[subsequentClasses.length];
+                for (int i = 0; i < subsequentClasses.length; i++) {
+                    this.subsequentClasses[i] = Class.forName(subsequentClasses[i]);
+                }
+            }
+        }
+
+        @Parameterized.Parameters
+        public static Iterable<Object[]> data() {
+            return testInputClasses(Long.class, Integer.class);
+        }
+
+        @Override
+        protected void callEqualMethod(DocStoreFinder finderUnderTest) {
+            finderUnderTest.byClass(firstClass, subsequentClasses);
+        }
+
+        @Override
+        protected void callNotEqualMethod(DocStoreFinder finderUnderTest) {
+            finderUnderTest.byClassNot(firstClass, subsequentClasses);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class DocStoreClassNameChain extends ForDocStoreFinder {
+
+        private final String firstClassName;
+        private final String[] subsequentClassNames;
+
+        public DocStoreClassNameChain(String firstClassName,
+                                      Object[] subsequentClassNames,
+                                      List<Finder.WhereElement> expectedEqualsOrElements,
+                                      List<Finder.WhereElement> expectedNotEqualsAndElements,
+                                      List<Object> expectedReplacements) throws Exception {
+            super(expectedEqualsOrElements, expectedNotEqualsAndElements, expectedReplacements);
+            this.firstClassName = firstClassName;
+            this.subsequentClassNames = subsequentClassNames == null
+                    ? null
+                    : Arrays.copyOf(subsequentClassNames, subsequentClassNames.length, String[].class);
+        }
+
+        @Parameterized.Parameters
+        public static Iterable<Object[]> data() {
+            return testInputClasses(Long.class, Integer.class);
+        }
+
+        @Override
+        protected void callEqualMethod(DocStoreFinder finderUnderTest) {
+            finderUnderTest.byClassName(firstClassName, subsequentClassNames);
+        }
+
+        @Override
+        protected void callNotEqualMethod(DocStoreFinder finderUnderTest) {
+            finderUnderTest.byClassNameNot(firstClassName, subsequentClassNames);
+        }
+    }
+
+    static Iterable<Object[]> testInputClasses(Class first, Class... subsequent) {
+        String firstName = first.getName();
+        if (subsequent == null) {
+            return testInput("class_name", firstName, null);
+        }
+
+        String[] subsequentNames = new String[subsequent.length];
+        for (int i = 0; i < subsequent.length; i++) {
+            subsequentNames[i] = subsequent[i].getName();
+        }
+        return testInput("class_name", firstName, subsequentNames);
+    }
+
+    static Iterable<Object[]> testInput(String column, Object first, Object... subsequent) {
+        List<Finder.WhereElement> expectedEqualsOrElements = new ArrayList<>(3 + (subsequent == null ? 0 : subsequent.length) * 2);
+        List<Finder.WhereElement> expectedNotEqualsAndElements = new ArrayList<>(3 + (subsequent == null ? 0 : subsequent.length) * 2);
+        expectedEqualsOrElements.add(Finder.WhereElement.createGroupStart());
+        expectedNotEqualsAndElements.add(Finder.WhereElement.createGroupStart());
+        expectedEqualsOrElements.add(Finder.WhereElement.createCondition(column, Finder.OP_EQ, first));
+        expectedNotEqualsAndElements.add(Finder.WhereElement.createCondition(column, Finder.OP_NE, first));
+        for (Object o : subsequent) {
+            expectedEqualsOrElements.add(Finder.WhereElement.createOr());
+            expectedEqualsOrElements.add(Finder.WhereElement.createCondition(column, Finder.OP_EQ, o));
+            expectedNotEqualsAndElements.add(Finder.WhereElement.createAnd());
+            expectedNotEqualsAndElements.add(Finder.WhereElement.createCondition(column, Finder.OP_NE, o));
+        }
+        expectedEqualsOrElements.add(Finder.WhereElement.createGroupEnd());
+        expectedNotEqualsAndElements.add(Finder.WhereElement.createGroupEnd());
+
+        List<Object> expectedReplacements = new ArrayList<>(1 + (subsequent == null ? 0 : subsequent.length));
+        expectedReplacements.add(first);
+        expectedReplacements.addAll(Arrays.asList(subsequent));
+
+        return Arrays.asList(new Object[][] {
+                {   // 00: single element
+                        first,
+                        null,
+                        Arrays.asList(
+                                Finder.WhereElement.createGroupStart(),
+                                Finder.WhereElement.createCondition(column, Finder.OP_EQ, first),
+                                Finder.WhereElement.createGroupEnd()
+                        ),
+                        Arrays.asList(
+                                Finder.WhereElement.createGroupStart(),
+                                Finder.WhereElement.createCondition(column, Finder.OP_NE, first),
+                                Finder.WhereElement.createGroupEnd()
+                        ),
+                        Collections.singletonList(first)
+                },
+                {   // 01: multiple elements
+                        first,
+                        subsequent,
+                        expectedEqualsOrElements,
+                        expectedNotEqualsAndElements,
+                        expectedReplacements
+                }
+        });
+    }
+
+    private void assertValidExpectations() {
+        assertEquals(expectedEqualsOrElements.size(), expectedNotEqualsAndElements.size());
+        int countEqualsConditions = 0;
+        for (Finder.WhereElement whereElement : expectedEqualsOrElements) {
+            if (whereElement.type() == Finder.WhereElement.TYPE_CONDITION) {
+                countEqualsConditions++;
+            }
+        }
+        int countNotEqualsConditions = 0;
+        for (Finder.WhereElement whereElement : expectedNotEqualsAndElements) {
+            if (whereElement.type() == Finder.WhereElement.TYPE_CONDITION) {
+                countNotEqualsConditions++;
+            }
+        }
+        assertEquals(countEqualsConditions, countNotEqualsConditions);
+        assertEquals(countEqualsConditions, expectedReplacements.size());
+    }
+
+    protected static abstract class ForFinder extends FinderEqualsNotEqualsChainTest<Finder, Resolver> {
+
+        protected ForFinder(List<Finder.WhereElement> expectedEqualsOrElements, List<Finder.WhereElement> expectedNotEqualsAndElements, List<Object> expectedReplacements) {
+            super(Resolver.class, expectedEqualsOrElements, expectedNotEqualsAndElements, expectedReplacements);
+        }
+
+        @Override
+        protected Finder createFinder(DBMSIntegrator mockDbmsIntegrator, Resolver mockResolver) {
+            return new Finder(mockDbmsIntegrator, mockResolver) {};
+        }
+    }
+
+    protected static abstract class ForDocStoreFinder extends FinderEqualsNotEqualsChainTest<DocStoreFinder, DocStoreResolver> {
+
+        protected ForDocStoreFinder(List<Finder.WhereElement> expectedEqualsOrElements, List<Finder.WhereElement> expectedNotEqualsAndElements, List<Object> expectedReplacements) {
+            super(DocStoreResolver.class, expectedEqualsOrElements, expectedNotEqualsAndElements, expectedReplacements);
+        }
+
+        @Override
+        protected DocStoreFinder createFinder(DBMSIntegrator mockDbmsIntegrator, DocStoreResolver mockResolver) {
+            return new DocStoreFinder(mockDbmsIntegrator, mockResolver) {};
+        }
+    }
+}

--- a/forsuredbapi/src/test/java/com/fsryan/forsuredb/api/FinderGroupTest.java
+++ b/forsuredbapi/src/test/java/com/fsryan/forsuredb/api/FinderGroupTest.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
-public class FinderGroupTest extends FinderTest {
+public class FinderGroupTest extends FinderTest.ForFinder {
 
     @Test
     public void shouldAddStartGroupWhenStartingGroupAnd() {

--- a/forsuredbapi/src/test/java/com/fsryan/forsuredb/api/FinderPaginationTest.java
+++ b/forsuredbapi/src/test/java/com/fsryan/forsuredb/api/FinderPaginationTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
-public abstract class FinderPaginationTest extends FinderTest {
+public abstract class FinderPaginationTest extends FinderTest.ForFinder {
 
     private final int fromTop;
     private final int offsetFromTop;
@@ -133,7 +133,7 @@ public abstract class FinderPaginationTest extends FinderTest {
         }
     }
 
-    public static class ExceptionCases extends FinderTest {
+    public static class ExceptionCases extends FinderTest.ForFinder {
 
         @Test(expected = IllegalStateException.class)
         public void shouldThrowWhenCallingFromTopThenFromBottomWithPositiveIntegers() {

--- a/forsuredbcompiler/src/test/resources/example_finder.txt
+++ b/forsuredbcompiler/src/test/resources/example_finder.txt
@@ -2,8 +2,6 @@ package com.fsryan.annotationprocessor.generator.code;
 
 import com.fsryan.forsuredb.api.Conjunction;
 import com.fsryan.forsuredb.api.Finder;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * <p>
@@ -43,17 +41,13 @@ public class TestTable3Finder<R extends TestTable3Resolver> extends Finder<R, Te
      */
     public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byAppRating(double exactMatch,
             double... orExactMatches) {
-        if (orExactMatches.length == 0) {
-            addToBuf("app_rating", OP_EQ, exactMatch);
+        whereElements.add(Finder.WhereElement.createGroupStart());
+        addToBuf("app_rating", OP_EQ, exactMatch);
+        for(int i = 0; i < (orExactMatches == null ? 0 : orExactMatches.length); i++) {
+            whereElements.add(Finder.WhereElement.createOr());
+            addToBuf("app_rating", OP_EQ, orExactMatches[i]);
         }
-        else {
-            List<Double> inclusionFilter = new ArrayList<Double>(1 + orExactMatches.length);
-            inclusionFilter.add(exactMatch);
-            for (double toInclude : orExactMatches) {
-                inclusionFilter.add(toInclude);
-            }
-            addEqualsOrChainToBuf("app_rating", inclusionFilter);
-        }
+        whereElements.add(Finder.WhereElement.createGroupEnd());
         return conjunction;
     }
 
@@ -64,8 +58,15 @@ public class TestTable3Finder<R extends TestTable3Resolver> extends Finder<R, Te
      * @param exclusion
      * @return a {@link com.fsryan.forsuredb.api.Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
      */
-    public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byAppRatingNot(double exclusion) {
+    public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byAppRatingNot(double exclusion,
+            double... furtherExclusions) {
+        whereElements.add(Finder.WhereElement.createGroupStart());
         addToBuf("app_rating", OP_NE, exclusion);
+        for(int i = 0; i < (furtherExclusions == null ? 0 : furtherExclusions.length); i++) {
+            whereElements.add(Finder.WhereElement.createAnd());
+            addToBuf("app_rating", OP_NE, furtherExclusions[i]);
+        }
+        whereElements.add(Finder.WhereElement.createGroupEnd());
         return conjunction;
     }
 
@@ -150,17 +151,13 @@ public class TestTable3Finder<R extends TestTable3Resolver> extends Finder<R, Te
      */
     public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byGlobalId(long exactMatch,
             long... orExactMatches) {
-        if (orExactMatches.length == 0) {
-            addToBuf("global_id", OP_EQ, exactMatch);
+        whereElements.add(Finder.WhereElement.createGroupStart());
+        addToBuf("global_id", OP_EQ, exactMatch);
+        for(int i = 0; i < (orExactMatches == null ? 0 : orExactMatches.length); i++) {
+            whereElements.add(Finder.WhereElement.createOr());
+            addToBuf("global_id", OP_EQ, orExactMatches[i]);
         }
-        else {
-            List<Long> inclusionFilter = new ArrayList<Long>(1 + orExactMatches.length);
-            inclusionFilter.add(exactMatch);
-            for (long toInclude : orExactMatches) {
-                inclusionFilter.add(toInclude);
-            }
-            addEqualsOrChainToBuf("global_id", inclusionFilter);
-        }
+        whereElements.add(Finder.WhereElement.createGroupEnd());
         return conjunction;
     }
 
@@ -171,8 +168,15 @@ public class TestTable3Finder<R extends TestTable3Resolver> extends Finder<R, Te
      * @param exclusion
      * @return a {@link com.fsryan.forsuredb.api.Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
      */
-    public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byGlobalIdNot(long exclusion) {
+    public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byGlobalIdNot(long exclusion,
+            long... furtherExclusions) {
+        whereElements.add(Finder.WhereElement.createGroupStart());
         addToBuf("global_id", OP_NE, exclusion);
+        for(int i = 0; i < (furtherExclusions == null ? 0 : furtherExclusions.length); i++) {
+            whereElements.add(Finder.WhereElement.createAnd());
+            addToBuf("global_id", OP_NE, furtherExclusions[i]);
+        }
+        whereElements.add(Finder.WhereElement.createGroupEnd());
         return conjunction;
     }
 
@@ -257,17 +261,13 @@ public class TestTable3Finder<R extends TestTable3Resolver> extends Finder<R, Te
      */
     public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byLoginCount(int exactMatch,
             int... orExactMatches) {
-        if (orExactMatches.length == 0) {
-            addToBuf("login_count", OP_EQ, exactMatch);
+        whereElements.add(Finder.WhereElement.createGroupStart());
+        addToBuf("login_count", OP_EQ, exactMatch);
+        for(int i = 0; i < (orExactMatches == null ? 0 : orExactMatches.length); i++) {
+            whereElements.add(Finder.WhereElement.createOr());
+            addToBuf("login_count", OP_EQ, orExactMatches[i]);
         }
-        else {
-            List<Integer> inclusionFilter = new ArrayList<Integer>(1 + orExactMatches.length);
-            inclusionFilter.add(exactMatch);
-            for (int toInclude : orExactMatches) {
-                inclusionFilter.add(toInclude);
-            }
-            addEqualsOrChainToBuf("login_count", inclusionFilter);
-        }
+        whereElements.add(Finder.WhereElement.createGroupEnd());
         return conjunction;
     }
 
@@ -278,8 +278,15 @@ public class TestTable3Finder<R extends TestTable3Resolver> extends Finder<R, Te
      * @param exclusion
      * @return a {@link com.fsryan.forsuredb.api.Conjunction.GroupableAndOr} that allows you to continue adding more query criteria
      */
-    public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byLoginCountNot(int exclusion) {
+    public Conjunction.GroupableAndOr<R, TestTable3Finder<R>> byLoginCountNot(int exclusion,
+            int... furtherExclusions) {
+        whereElements.add(Finder.WhereElement.createGroupStart());
         addToBuf("login_count", OP_NE, exclusion);
+        for(int i = 0; i < (furtherExclusions == null ? 0 : furtherExclusions.length); i++) {
+            whereElements.add(Finder.WhereElement.createAnd());
+            addToBuf("login_count", OP_NE, furtherExclusions[i]);
+        }
+        whereElements.add(Finder.WhereElement.createGroupEnd());
         return conjunction;
     }
 

--- a/integrationtest/src/test/java/com/fsyran/forsuredb/integrationtest/singletable/RetrievalTests.java
+++ b/integrationtest/src/test/java/com/fsyran/forsuredb/integrationtest/singletable/RetrievalTests.java
@@ -702,6 +702,71 @@ public class RetrievalTests {
     }
 
     @Test
+    @DisplayName("finding by id from multiple exact match criteria and some other criteria")
+    public void shouldFindRecordWithIdInExactMatchCriteriaAndSomeOtherCriteria() {
+        long id1 = randomStoredRecordId();
+        long id2 = randomStoredRecordId();
+        long id3 = randomStoredRecordId();
+        long id4 = randomStoredRecordId();
+        long id5 = randomStoredRecordId();
+        Set<Long> allowedIds = new HashSet<>(Arrays.asList(id1, id2, id3, id4, id5));
+
+        List<AllTypesTable.Record> actual = retrieveToList(
+                allTypesTable().find()
+                        .byId(id1, id2, id3, id4, id5)
+                        .and().byBooleanColumn()
+                        .then()
+                        .get()
+        );
+        List<AllTypesTable.Record> expected = savedRecordsWhere(asr -> booleanColOf(asr) && allowedIds.contains(idOf(asr)));
+
+        assertListEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("finding by id NOT from multiple exact match criteria")
+    public void shouldFindRecordWithIdNotInExactMatchCriteria() {
+        long id1 = randomStoredRecordId();
+        long id2 = randomStoredRecordId();
+        long id3 = randomStoredRecordId();
+        long id4 = randomStoredRecordId();
+        long id5 = randomStoredRecordId();
+        Set<Long> disallowedIds = new HashSet<>(Arrays.asList(id1, id2, id3, id4, id5));
+
+        List<AllTypesTable.Record> actual = retrieveToList(
+                allTypesTable().find()
+                        .byIdNot(id1, id2, id3, id4, id5)
+                        .then()
+                        .get()
+        );
+        List<AllTypesTable.Record> expected = savedRecordsWhere(asr -> !disallowedIds.contains(idOf(asr)));
+
+        assertListEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("finding by id NOT from multiple exact match criteria OR some other criteria")
+    public void shouldFindRecordWithIdNotInExactMatchCriteriaOrSomeOtherCriteria() {
+        long id1 = randomStoredRecordId();
+        long id2 = randomStoredRecordId();
+        long id3 = randomStoredRecordId();
+        long id4 = randomStoredRecordId();
+        long id5 = randomStoredRecordId();
+        Set<Long> disallowedIds = new HashSet<>(Arrays.asList(id1, id2, id3, id4, id5));
+
+        List<AllTypesTable.Record> actual = retrieveToList(
+                allTypesTable().find()
+                        .byIdNot(id1, id2, id3, id4, id5)
+                        .or().byBooleanColumn()
+                        .then()
+                        .get()
+        );
+        List<AllTypesTable.Record> expected = savedRecordsWhere(asr -> !disallowedIds.contains(idOf(asr)) || booleanColOf(asr));
+
+        assertListEquals(expected, actual);
+    }
+
+    @Test
     @DisplayName("finding by id from several match criteria using OR")
     public void shouldFindRecordWithIdInExactMatchCriteriaUsingOR() {
         long id1 = randomStoredRecordId();


### PR DESCRIPTION
The method was confusing and ultimately unnecessary. Instead of
using a specific method for adding an equals or chain, loop
through the varargs array, calling addToBuf for each value in the
array.

This comes with the additional necessity to surround all added
conditions with parentheses. Therefore, they get added to a group
first--even if there is only one value.