### PR TITLE
allow retrieval of null fields in projection

### DIFF
--- a/forsuredbapi/src/main/java/com/fsryan/forsuredb/api/Retriever.java
+++ b/forsuredbapi/src/main/java/com/fsryan/forsuredb/api/Retriever.java
@@ -33,6 +33,7 @@ public interface Retriever extends Closeable {
     float getFloat(String column);
     byte[] getBytes(String column);
     int getCount();
+    boolean isNull(String column);
 
     boolean isClosed();
     void close();

--- a/forsuredbcompiler/src/test/resources/example_getter.txt
+++ b/forsuredbcompiler/src/test/resources/example_getter.txt
@@ -2,6 +2,8 @@ package com.fsryan.annotationprocessor.generator.code;
 
 import com.fsryan.forsuredb.api.BaseGetter;
 import com.fsryan.forsuredb.api.Retriever;
+import java.lang.IllegalArgumentException;
+import java.lang.NumberFormatException;
 import java.lang.String;
 import java.math.BigDecimal;
 import javax.annotation.Generated;
@@ -29,11 +31,12 @@ public class TestTable3Getter extends BaseGetter implements TestTable3 {
      * </p>
      * @param retriever The {@link Retriever} that can pull column values from the current record
      * @return the value of column app_rating for the current record
-     * @throws java.lang.IllegalArgumentException when input retriever is null
+     * @throws IllegalArgumentException when input retriever is null
      */
     public double appRating(Retriever retriever) {
         throwIfNullRetriever(retriever);
-        return retriever.getDouble(disambiguateColumn("app_rating"));
+        String disambiguatedColumn = disambiguateColumn("app_rating");
+        return retriever.getDouble(disambiguatedColumn);
     }
 
     /**
@@ -42,10 +45,20 @@ public class TestTable3Getter extends BaseGetter implements TestTable3 {
      * </p>
      * @param retriever The {@link Retriever} that can pull column values from the current record
      * @return the value of column competitor_app_rating for the current record
-     * @throws java.lang.IllegalArgumentException when input retriever is null
+     * @throws IllegalArgumentException when input retriever is null
      */
     public BigDecimal competitorAppRating(Retriever retriever) {
-        return parseBigDecimalColumn(retriever, "competitor_app_rating");
+        throwIfNullRetriever(retriever);
+        String disambiguatedColumn = disambiguateColumn("competitor_app_rating");
+        if (retriever.isNull(disambiguatedColumn)) {
+            return null;
+        }
+        String val = retriever.getString(disambiguatedColumn);
+        try {
+            return new BigDecimal(val);
+        } catch (NumberFormatException nfe) {
+            throw new IllegalArgumentException("Looks like competitor_app_rating was not a class java.math.BigDecimal; actual value = " + val, nfe);
+        }
     }
 
     /**
@@ -54,11 +67,12 @@ public class TestTable3Getter extends BaseGetter implements TestTable3 {
      * </p>
      * @param retriever The {@link Retriever} that can pull column values from the current record
      * @return the value of column global_id for the current record
-     * @throws java.lang.IllegalArgumentException when input retriever is null
+     * @throws IllegalArgumentException when input retriever is null
      */
     public long globalId(Retriever retriever) {
         throwIfNullRetriever(retriever);
-        return retriever.getLong(disambiguateColumn("global_id"));
+        String disambiguatedColumn = disambiguateColumn("global_id");
+        return retriever.getLong(disambiguatedColumn);
     }
 
     /**
@@ -67,10 +81,11 @@ public class TestTable3Getter extends BaseGetter implements TestTable3 {
      * </p>
      * @param retriever The {@link Retriever} that can pull column values from the current record
      * @return the value of column login_count for the current record
-     * @throws java.lang.IllegalArgumentException when input retriever is null
+     * @throws IllegalArgumentException when input retriever is null
      */
     public int loginCount(Retriever retriever) {
         throwIfNullRetriever(retriever);
-        return retriever.getInt(disambiguateColumn("login_count"));
+        String disambiguatedColumn = disambiguateColumn("login_count");
+        return retriever.getInt(disambiguatedColumn);
     }
 }

--- a/forsuredbjdbc/src/main/java/com/fsryan/forsuredb/resultset/FSResultSet.java
+++ b/forsuredbjdbc/src/main/java/com/fsryan/forsuredb/resultset/FSResultSet.java
@@ -1140,6 +1140,16 @@ public class FSResultSet implements ResultSet, Retriever {
         }
     }
 
+    @Override
+    public boolean isNull(String column) {
+        try {
+            getObject(column);
+            return resultSet.wasNull();
+        } catch (SQLException sqle) {
+            throw new RuntimeException(sqle);
+        }
+    }
+
     /**
      * @return true if the operation succeeded--false otherwise
      */

--- a/forsuredbjdbc/src/test/java/com/fsryan/forsuredb/resultset/FSResultSetTest.java
+++ b/forsuredbjdbc/src/test/java/com/fsryan/forsuredb/resultset/FSResultSetTest.java
@@ -1,10 +1,8 @@
 package com.fsryan.forsuredb.resultset;
 
-import com.fsryan.forsuredb.api.Retriever;
 import org.junit.*;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.ByteArrayInputStream;
@@ -15,7 +13,8 @@ import java.sql.*;
 import java.util.Calendar;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class FSResultSetTest {
@@ -1334,5 +1333,19 @@ public class FSResultSetTest {
     public void shouldPassThroughGetPositionToGetRow() throws SQLException {
         fsResultSetUnderTest.getPosition();
         verify(mockResultSet).getRow();
+    }
+
+    @Test
+    public void shouldCorrectlyEvaluateColumnNull() throws SQLException {
+        when(mockResultSet.wasNull()).thenReturn(true);
+        assertTrue(fsResultSetUnderTest.isNull(columnLabel));
+        verify(mockResultSet).getObject(eq(columnLabel));
+    }
+
+    @Test
+    public void shouldCorrectlyEvaluateColumnNotNull() throws SQLException {
+        when(mockResultSet.wasNull()).thenReturn(false);
+        assertFalse(fsResultSetUnderTest.isNull(columnLabel));
+        verify(mockResultSet).getObject(eq(columnLabel));
     }
 }

--- a/integrationtest/src/test/java/com/fsyran/forsuredb/integrationtest/singletable/AllTypesTableTestUtil.java
+++ b/integrationtest/src/test/java/com/fsyran/forsuredb/integrationtest/singletable/AllTypesTableTestUtil.java
@@ -272,7 +272,7 @@ abstract class AllTypesTableTestUtil {
         return asr.getAttemptedRecord().bigIntegerColumn();
     }
 
-    private static AllTypesTable.Record extractRecordFrom(Retriever r) {
+    public static AllTypesTable.Record extractRecordFrom(Retriever r) {
         return AllTypesTable.Record.builder()
                 .bigDecimalColumn(allTypesApi.bigDecimalColumn(r))
                 .bigIntegerColumn(allTypesApi.bigIntegerColumn(r))

--- a/integrationtest/src/test/java/com/fsyran/forsuredb/integrationtest/singletable/BasicCreateRetrieveTest.java
+++ b/integrationtest/src/test/java/com/fsyran/forsuredb/integrationtest/singletable/BasicCreateRetrieveTest.java
@@ -50,8 +50,8 @@ public class BasicCreateRetrieveTest {
     @Test
     @DisplayName("Insert and retrieve records that have null values")
     public void shouldCorrectlyInsertAndRetrieveRecordsWithNullValues() throws Exception {
-        AllTypesTable.Record record = AllTypesTable.Record.createRandomWithNullableElementsNull();
-        AttemptedSavePair<AllTypesTable.Record> savePair = insertRecord(record);
+        AllTypesTable.Record inserted = AllTypesTable.Record.createRandomWithNullableElementsNull();
+        AttemptedSavePair<AllTypesTable.Record> savePair = insertRecord(inserted);
         if (savePair.getResult().exception() != null) {
             throw savePair.getResult().exception();
         }
@@ -69,7 +69,8 @@ public class BasicCreateRetrieveTest {
                     .and().byByteArrayColumn(null)
                 .then()
                 .get();
-        // TODO: call Resolver.getCount() when https://github.com/ryansgot/forsuredbcompiler/issues/162 is done
-        assertTrue(r.moveToFirst());
+        AllTypesTable.Record retrieved = extractRecordFrom(r);
+        r.close();
+        assertEquals(inserted, retrieved);
     }
 }

--- a/integrationtest/src/test/java/com/fsyran/forsuredb/integrationtest/singletable/RetrievalTests.java
+++ b/integrationtest/src/test/java/com/fsyran/forsuredb/integrationtest/singletable/RetrievalTests.java
@@ -3609,6 +3609,7 @@ public class RetrievalTests {
             assertEquals(savedRecord.longColumn(), api.longColumn(r));
             assertEquals(savedRecord.floatColumn(), api.floatColumn(r), 0.0000001F);
             assertEquals(savedRecord.doubleColumn(), api.doubleColumn(r), 0.0000000001D);
+            assertCallThrowsException(r, api::id);
             assertCallThrowsException(r, api::bigDecimalColumn);
             assertCallThrowsException(r, api::bigIntegerColumn);
             assertCallThrowsException(r, api::stringColumn);
@@ -3619,7 +3620,6 @@ public class RetrievalTests {
             assertCallThrowsException(r, api::longWrapperColumn);
             assertCallThrowsException(r, api::floatWrapperColumn);
             assertCallThrowsException(r, api::doubleWrapperColumn);
-            assertCallThrowsException(r, api::id);
             assertCallThrowsException(r, api::created);
             assertCallThrowsException(r, api::deleted);
             assertCallThrowsException(r, api::modified);


### PR DESCRIPTION
This is a bug I found that occurred because I didn't test true equivalence of the inserted and retrieved values (in the null insertion and retrieval test)